### PR TITLE
Fix: Adjust CXXFLAGS for macOS RobotJS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Rebuild native modules for Electron (RobotJS)
         env:
-          CXXFLAGS: ${{ matrix.os == 'macos-latest' && '-std=c++20 -stdlib=libc++' || '' }}
+          CXXFLAGS: ${{ matrix.os == 'macos-latest' && '-std=c++17 -stdlib=libc++' || '' }}
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-latest' && '11.0' || '' }}
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then


### PR DESCRIPTION
I've changed CXXFLAGS from -std=c++20 to -std=c++17 for the RobotJS rebuild step on macOS. This is a common adjustment to improve compatibility for native modules that may not fully support the latest C++ standard or have issues with specific Clang versions in GitHub Actions runners.

This change aims to resolve runtime errors encountered with RobotJS on macOS builds by ensuring a more compatible compilation environment. The rest of the workflow, including manual dispatch capabilities, remains unchanged.